### PR TITLE
Fix: 동일 사용자의 다중기기 중복 알림 문제 해결 (알림 중복 저장문제를Distinct 로 해결)

### DIFF
--- a/src/main/java/org/scoula/push/mapper/SubscriptionMapper.java
+++ b/src/main/java/org/scoula/push/mapper/SubscriptionMapper.java
@@ -28,9 +28,6 @@ public interface SubscriptionMapper {
     // 사용자의 구독 상태 확인 (하나라도 활성화되어 있으면 true)
     boolean isUserSubscribed(@Param("userId") Long userId);
 
-    // 신규 정책 알림 활성 구독자 조회
-    List<SubscriptionVO> findActiveNewPolicySubscribers();
-    
     // 특정 사용자의 북마크 알림이 활성화된 모든 토큰 조회
     List<String> findActiveBookmarkTokensByUserId(@Param("userId") Long userId);
     

--- a/src/main/java/org/scoula/push/service/notification/NewPolicyNotificationService.java
+++ b/src/main/java/org/scoula/push/service/notification/NewPolicyNotificationService.java
@@ -151,7 +151,7 @@ public class NewPolicyNotificationService {
      */
     private List<SubscriptionVO> getNewPolicySubscribers() {
         try {
-            return subscriptionMapper.findActiveNewPolicySubscribers();
+            return subscriptionMapper.findActiveByNotificationType("NEW_POLICY");
         } catch (Exception e) {
             log.error("[신규 정책 알림] 구독자 조회 중 오류", e);
             return List.of();

--- a/src/main/resources/org/scoula/policyInteraction/mapper/PolicyInteractionMapper.xml
+++ b/src/main/resources/org/scoula/policyInteraction/mapper/PolicyInteractionMapper.xml
@@ -63,7 +63,7 @@
 
     <!-- 북마크 알림을 구독한 사용자의 북마크만 조회 (최적화된 알림 발송용) -->
     <select id="getBookmarksWithActiveSubscription" resultType="org.scoula.policyInteraction.domain.YouthPolicyBookmarkVO">
-        SELECT
+        SELECT DISTINCT
             b.id,
             b.user_id AS userId,
             b.policy_id AS policyId,

--- a/src/main/resources/org/scoula/push/mapper/SubscriptionMapper.xml
+++ b/src/main/resources/org/scoula/push/mapper/SubscriptionMapper.xml
@@ -31,7 +31,9 @@
 
     <!-- 특정 알림 타입의 활성 구독자 조회 -->
     <select id="findActiveByNotificationType" resultType="org.scoula.push.domain.SubscriptionVO">
-        SELECT * FROM subscription
+        SELECT DISTINCT
+            user_id AS userId
+        FROM subscription
         WHERE 
         <choose>
             <when test="notificationType == 'BOOKMARK'">
@@ -70,14 +72,6 @@
         AND (is_active_bookmark = true OR is_active_top3 = true OR is_active_new_policy = true OR is_active_feedback = true)
     </select>
 
-    <!-- 신규 정책 알림 활성 구독자 조회 -->
-    <select id="findActiveNewPolicySubscribers" resultType="org.scoula.push.domain.SubscriptionVO">
-        SELECT * FROM subscription
-        WHERE is_active_new_policy = true
-        AND fcm_token IS NOT NULL
-        AND fcm_token != ''
-    </select>
-    
     <!-- 특정 사용자의 북마크 알림이 활성화된 모든 토큰 조회 -->
     <select id="findActiveBookmarkTokensByUserId" resultType="String">
         SELECT fcm_token FROM subscription


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #48 

## 📝 작업 내용 요약

알림 중복 저장 이슈 해결
기존 join 쿼리에 distinct 추가하는 것으로 해결했습니다.

[알림 저장 및 전송 방식]
1, 특정 타입의 알림을 구독한 구독자 조회 
2. 유저별로 알림을 동기식으로 저장
3. 유저별로 활성화된 FCM 토큰 조회
4. 각 토큰에 개인 맞춤형 메세지를 구성하여 비동기식 발송


## 🛠️ PR 유형

어떤 변경 사항이 있나요?(아래 형식으로 알사서 변경하여 PR 올리면 됨)

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(ex 오타 수정, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
